### PR TITLE
Add/Remove Sections; Links work better

### DIFF
--- a/WikiFrontEnd/src/app/app.module.ts
+++ b/WikiFrontEnd/src/app/app.module.ts
@@ -2,7 +2,7 @@ import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { HttpClientModule } from '@angular/common/http';
-import { MarkdownModule } from 'ngx-markdown';
+import { MarkdownModule, MarkedOptions } from 'ngx-markdown';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { LandingComponent } from './components/landing/landing.component';
@@ -20,6 +20,8 @@ import { RouterModule, Routes } from '@angular/router';
 //Imports Avatar Module
 import { AvatarModule } from 'ngx-avatar';
 import { TrendingPipe } from './components/landing/trending.pipe';
+import { MARKDOWN_SETTINGS } from './markdown.settings';
+import { DisplayMarkdownComponent } from './components/display-markdown/display-markdown.component';
 
 //Declares Routes for components
 const appRoutes: Routes = [
@@ -36,7 +38,8 @@ const appRoutes: Routes = [
     ViewEditPageComponent,
     ViewEditSectionComponent,
     AboutPageComponent,
-    TrendingPipe
+    TrendingPipe,
+    DisplayMarkdownComponent
   ],
   imports: [
     ReactiveFormsModule,
@@ -51,7 +54,7 @@ const appRoutes: Routes = [
     MatSidenavModule,
     MatButtonModule,
     BrowserAnimationsModule,
-    MarkdownModule.forRoot(),
+    MarkdownModule.forRoot({markedOptions: {provide: MarkedOptions, useValue: MARKDOWN_SETTINGS}}),
     RouterModule.forRoot(
       appRoutes,
       {enableTracing: true} // debugging purposes only

--- a/WikiFrontEnd/src/app/components/display-markdown/display-markdown.component.html
+++ b/WikiFrontEnd/src/app/components/display-markdown/display-markdown.component.html
@@ -1,0 +1,4 @@
+<div #myDiv
+  markdown
+  [data]="data"
+  ></div>

--- a/WikiFrontEnd/src/app/components/display-markdown/display-markdown.component.spec.ts
+++ b/WikiFrontEnd/src/app/components/display-markdown/display-markdown.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DisplayMarkdownComponent } from './display-markdown.component';
+
+describe('DisplayMarkdownComponent', () => {
+  let component: DisplayMarkdownComponent;
+  let fixture: ComponentFixture<DisplayMarkdownComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ DisplayMarkdownComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DisplayMarkdownComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/WikiFrontEnd/src/app/components/display-markdown/display-markdown.component.ts
+++ b/WikiFrontEnd/src/app/components/display-markdown/display-markdown.component.ts
@@ -1,0 +1,34 @@
+import { Component, Input, OnChanges, SimpleChanges, ViewChild, ElementRef, NgZone } from '@angular/core';
+import { MarkdownComponent } from 'ngx-markdown';
+import { Router } from '@angular/router';
+
+@Component({
+  selector: 'app-display-markdown',
+  templateUrl: './display-markdown.component.html',
+  styleUrls: ['./display-markdown.component.css']
+})
+export class DisplayMarkdownComponent implements OnChanges {
+  @ViewChild('myDiv') theDiv: MarkdownComponent;
+  @Input() data: string;
+
+  constructor(private zone: NgZone, private router: Router) { }
+
+  ngOnChanges(changes: SimpleChanges) {
+    this.makeRouterLinks();
+  }
+
+  private makeRouterLinks() {
+    window.setTimeout(() => {
+      console.log(this.theDiv);
+      const links = this.theDiv.element.nativeElement.getElementsByClassName('convert-link') as HTMLCollectionOf<HTMLAnchorElement>;
+      const router = this.router;
+      for (const link of Array.from(links)) {
+        link.addEventListener('click', function(e) {
+          router.navigate(['wiki', this.dataset.href]);
+          e.preventDefault();
+        });
+      }
+    }, 0);
+  }
+
+}

--- a/WikiFrontEnd/src/app/components/landing/trending.pipe.ts
+++ b/WikiFrontEnd/src/app/components/landing/trending.pipe.ts
@@ -1,8 +1,7 @@
 import {Pipe, PipeTransform} from '@angular/core';
 import { Page } from '../../models/ud-pages';
-import { ConsoleReporter } from 'jasmine';
 
-@Pipe({name: 'trending'}) export class TrendingPipe {
+@Pipe({name: 'trending'}) export class TrendingPipe implements PipeTransform {
   transform(
     values: Page[],
   ) {

--- a/WikiFrontEnd/src/app/components/view-edit-page/view-edit-page.component.css
+++ b/WikiFrontEnd/src/app/components/view-edit-page/view-edit-page.component.css
@@ -2,3 +2,9 @@ h2 {
   max-width: 1000px;
   margin: auto;
 }
+
+.centerChild {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}

--- a/WikiFrontEnd/src/app/components/view-edit-page/view-edit-page.component.html
+++ b/WikiFrontEnd/src/app/components/view-edit-page/view-edit-page.component.html
@@ -5,7 +5,8 @@
 
   <app-view-edit-section *ngFor="let section of (page | async).sections; let i = index"
     [section]="section"
-    (saveModification)="sectionChanged(i, $event)">
+    (saveModification)="sectionChanged(i, $event)"
+    (saveDeletion)="deleteSection(i)">
   </app-view-edit-section>
 
 

--- a/WikiFrontEnd/src/app/components/view-edit-page/view-edit-page.component.html
+++ b/WikiFrontEnd/src/app/components/view-edit-page/view-edit-page.component.html
@@ -9,6 +9,10 @@
     (saveDeletion)="deleteSection(i)">
   </app-view-edit-section>
 
+  <div class='centerChild'>
+    <button mat-fab color="accent" (click)="addSection()">+</button>
+  </div>
+
 
 </ng-template>
 <ng-template #loading>

--- a/WikiFrontEnd/src/app/components/view-edit-page/view-edit-page.component.ts
+++ b/WikiFrontEnd/src/app/components/view-edit-page/view-edit-page.component.ts
@@ -55,4 +55,10 @@ export class ViewEditPageComponent implements OnInit {
       });
   }
 
+  addSection() {
+    this.latest.sections.push(
+      {title: 'New Section', content: 'Add content to your section here!\nYou can even use ***markdown*** styling!'}
+    );
+  }
+
 }

--- a/WikiFrontEnd/src/app/components/view-edit-page/view-edit-page.component.ts
+++ b/WikiFrontEnd/src/app/components/view-edit-page/view-edit-page.component.ts
@@ -57,7 +57,7 @@ export class ViewEditPageComponent implements OnInit {
 
   addSection() {
     this.latest.sections.push(
-      {title: 'New Section', content: 'Add content to your section here!\nYou can even use ***markdown*** styling!'}
+      {title: '', content: ''}
     );
   }
 

--- a/WikiFrontEnd/src/app/components/view-edit-page/view-edit-page.component.ts
+++ b/WikiFrontEnd/src/app/components/view-edit-page/view-edit-page.component.ts
@@ -42,4 +42,17 @@ export class ViewEditPageComponent implements OnInit {
       });
   }
 
+  deleteSection(index: number) {
+    const newData: Page = {
+      name: this.latest.name,
+      sections: Array.from(this.latest.sections)
+    };
+    newData.sections.splice(index, 1);
+
+    this.pagesService.updatePage(newData.name, newData)
+      .subscribe(() => {
+        this.latest.sections.splice(index, 1);
+      });
+  }
+
 }

--- a/WikiFrontEnd/src/app/components/view-edit-section/view-edit-section.component.html
+++ b/WikiFrontEnd/src/app/components/view-edit-section/view-edit-section.component.html
@@ -6,6 +6,7 @@
           <form>
             <button mat-button (click)="cancel()">Cancel</button>
             <button mat-button (click)="save()" [disabled]="!modified">Save</button>
+            <button mat-raised-button color="warn" (click)="delete()" style='float: right'>Delete</button>
             <mat-form-field style="width: 100%">
               <input matInput name="section-title" type='text' placeholder="Section Title" [(ngModel)]="current.title" (ngModelChange)="contentChanged()" />
             </mat-form-field>

--- a/WikiFrontEnd/src/app/components/view-edit-section/view-edit-section.component.html
+++ b/WikiFrontEnd/src/app/components/view-edit-section/view-edit-section.component.html
@@ -22,7 +22,7 @@
       <div id='setHeightWrapper' [style.minHeight]="minHeight">
         <button mat-button (click)="changeDrawer(true)" *ngIf="!isOpen" style="float: right;">EDIT</button>
         <mat-card-title>{{ current.title }}</mat-card-title>
-        <markdown [data]="current.content"></markdown>
+        <app-display-markdown [data]="current.content"></app-display-markdown>
       </div>
     </mat-drawer-container>
   </mat-card-content>

--- a/WikiFrontEnd/src/app/components/view-edit-section/view-edit-section.component.html
+++ b/WikiFrontEnd/src/app/components/view-edit-section/view-edit-section.component.html
@@ -5,7 +5,7 @@
         <div #theDrawer>
           <form>
             <button mat-button (click)="cancel()">Cancel</button>
-            <button mat-button (click)="save()" [disabled]="!modified">Save</button>
+            <button mat-button (click)="save()" [disabled]="!saveable">Save</button>
             <button mat-raised-button color="warn" (click)="delete()" style='float: right'>Delete</button>
             <mat-form-field style="width: 100%">
               <input matInput name="section-title" type='text' placeholder="Section Title" [(ngModel)]="current.title" (ngModelChange)="contentChanged()" />
@@ -14,7 +14,7 @@
               <textarea matInput name="section-content" placeholder="Section Content" [(ngModel)]="current.content" cdkTextareaAutosize cdkAutosizeMinRows="5" (ngModelChange)="contentChanged()"></textarea>
             </mat-form-field>
             <button mat-button (click)="cancel()">Cancel</button>
-            <button mat-button (click)="save()" [disabled]="!modified">Save</button>
+            <button mat-button (click)="save()" [disabled]="!saveable">Save</button>
           </form>
         </div>
       </mat-drawer>

--- a/WikiFrontEnd/src/app/components/view-edit-section/view-edit-section.component.ts
+++ b/WikiFrontEnd/src/app/components/view-edit-section/view-edit-section.component.ts
@@ -14,7 +14,7 @@ export class ViewEditSectionComponent implements OnInit, OnChanges {
   current: Section;
   public isOpen = false;
   public minHeight = '0px';
-  public modified = false;
+  public saveable = false;
   @Output() saveModification: EventEmitter<ViewEditSectionComponent> = new EventEmitter();
   @Output() saveDeletion: EventEmitter<ViewEditSectionComponent> = new EventEmitter();
 
@@ -26,6 +26,9 @@ export class ViewEditSectionComponent implements OnInit, OnChanges {
   ngOnChanges(changes: SimpleChanges) {
     if (changes.section) {
       this.current = Object.assign({}, this.section);
+      if (this.current.title === '' && this.current.content === '') {
+        this.changeDrawer(true);
+      }
     }
   }
 
@@ -35,8 +38,12 @@ export class ViewEditSectionComponent implements OnInit, OnChanges {
   }
 
   cancel() {
-    this.current = Object.assign({}, this.section);
-    this.changeDrawer(false);
+    if (this.section.title === '' || this.section.content === '') {
+      this.delete();
+    } else {
+      this.current = Object.assign({}, this.section);
+      this.changeDrawer(false);
+    }
   }
 
   save() {
@@ -54,7 +61,13 @@ export class ViewEditSectionComponent implements OnInit, OnChanges {
   }
 
   contentChanged() {
-    this.modified = !(this.current.title === this.section.title && this.current.content === this.section.content);
+    this.saveable = (
+      (
+        this.current.title !== this.section.title ||
+        this.current.content !== this.section.content
+      ) &&
+      this.current.title !== '' &&
+      this.current.content !== '');
     this.updateHeight();
   }
 

--- a/WikiFrontEnd/src/app/components/view-edit-section/view-edit-section.component.ts
+++ b/WikiFrontEnd/src/app/components/view-edit-section/view-edit-section.component.ts
@@ -16,6 +16,7 @@ export class ViewEditSectionComponent implements OnInit, OnChanges {
   public minHeight = '0px';
   public modified = false;
   @Output() saveModification: EventEmitter<ViewEditSectionComponent> = new EventEmitter();
+  @Output() saveDeletion: EventEmitter<ViewEditSectionComponent> = new EventEmitter();
 
   constructor(private ngZone: NgZone) { }
 
@@ -40,6 +41,10 @@ export class ViewEditSectionComponent implements OnInit, OnChanges {
 
   save() {
     this.saveModification.emit(this);
+  }
+
+  delete() {
+    this.saveDeletion.emit(this);
   }
 
   finishSave() {

--- a/WikiFrontEnd/src/app/markdown.settings.ts
+++ b/WikiFrontEnd/src/app/markdown.settings.ts
@@ -1,0 +1,11 @@
+import { MarkedOptions, MarkedRenderer } from 'ngx-markdown';
+
+const renderer = new MarkedRenderer();
+
+renderer.link = (href, title, text) => {
+  return `<a class='convert-link' href='#' data-href='${href}' title='${title || ''}'>${text}</a>`;
+};
+
+export const MARKDOWN_SETTINGS: MarkedOptions = {
+  renderer: renderer
+};

--- a/WikiFrontEnd/src/app/markdown.settings.ts
+++ b/WikiFrontEnd/src/app/markdown.settings.ts
@@ -3,7 +3,12 @@ import { MarkedOptions, MarkedRenderer } from 'ngx-markdown';
 const renderer = new MarkedRenderer();
 
 renderer.link = (href, title, text) => {
-  return `<a class='convert-link' href='#' data-href='${href}' title='${title || ''}'>${text}</a>`;
+  const outsideRegex = /^https?:\/\//;
+  if (outsideRegex.test(href)) {
+    return `<a href='${href}' title='${title}' target='_blank'>${text}</a>`;
+  } else {
+    return `<a class='convert-link' href='#' data-href='${href}' title='${title || ''}'>${text}</a>`;
+  }
 };
 
 export const MARKDOWN_SETTINGS: MarkedOptions = {


### PR DESCRIPTION
Users can add and delete sections from pages.
Links that don't start with http:// or https:// will use the router to keep the app single-page. This wasn't easy.